### PR TITLE
feat: Implement user profile editing and image upload

### DIFF
--- a/com/grv/grvapp/controllers/UserController.java
+++ b/com/grv/grvapp/controllers/UserController.java
@@ -1,0 +1,109 @@
+package com.grv.grvapp.controllers;
+
+import com.grv.grvapp.dtos.UserProfileUpdateRequestDto;
+import com.grv.grvapp.models.User;
+import com.grv.grvapp.services.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * REST controller for managing user-related operations such as profile updates and image uploads.
+ * Base path for all endpoints in this controller is /api/users.
+ */
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+    private final UserService userService;
+
+    /**
+     * Constructs a UserController with the necessary UserService.
+     * @param userService The service handling user business logic.
+     */
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * Updates a user's profile information.
+     * Accepts a DTO with fields to update.
+     *
+     * @param userId The ID of the user whose profile is to be updated.
+     * @param requestDto The DTO containing updated data for the user's profile.
+     * @return ResponseEntity containing the updated User object and HTTP status 200 (OK).
+     *         If the user is not found, a global exception handler should handle ResourceNotFoundException (e.g., return 404).
+     */
+    @PutMapping("/{userId}/profile")
+    public ResponseEntity<User> updateUserProfile(@PathVariable Long userId, @RequestBody UserProfileUpdateRequestDto requestDto) {
+        User updatedUser = userService.updateUserProfile(userId, requestDto);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    /**
+     * Uploads or updates a user's profile image.
+     *
+     * @param userId The ID of the user whose profile image is being uploaded.
+     * @param imageFile The image file sent as part of a multipart request, under the name "image".
+     * @return ResponseEntity containing the updated User object (HTTP 200 OK),
+     *         or an error message with HTTP status 500 (Internal Server Error) if an IOException occurs during file processing.
+     *         If the user is not found, a global exception handler should handle ResourceNotFoundException (e.g., return 404).
+     */
+    @PostMapping("/{userId}/image")
+    public ResponseEntity<?> uploadProfileImage(@PathVariable Long userId, @RequestParam("image") MultipartFile imageFile) {
+        try {
+            User updatedUser = userService.uploadProfileImage(userId, imageFile);
+            // Consider returning a more specific DTO if not all User fields are relevant to the client after upload.
+            return ResponseEntity.ok(updatedUser);
+        } catch (IOException e) {
+            logger.error("Error uploading profile image for user ID {}: {}", userId, e.getMessage(), e);
+            // It's good practice to return a generic error message to the client for security reasons,
+            // while logging the detailed error on the server.
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred while uploading the image.");
+        }
+        // Note: ResourceNotFoundException thrown by userService is expected to be handled by a global exception handler (e.g., @ControllerAdvice)
+        // which would typically return a 404 Not Found response.
+    }
+
+    /**
+     * Retrieves a user's profile image.
+     *
+     * @param userId The ID of the user whose profile image is to be retrieved.
+     * @return ResponseEntity containing the image bytes with Content-Type header (e.g., image/jpeg) and HTTP status 200 (OK).
+     *         Returns HTTP status 404 (Not Found) if the user or their image is not found.
+     */
+    @GetMapping("/{userId}/image")
+    public ResponseEntity<byte[]> getProfileImage(@PathVariable Long userId) {
+        byte[] imageBytes = userService.getProfileImage(userId);
+
+        if (imageBytes != null && imageBytes.length > 0) {
+            HttpHeaders headers = new HttpHeaders();
+            // Defaulting to IMAGE_JPEG. For a production application, it's better to:
+            // 1. Store the original media type of the image when uploaded.
+            // 2. Or, use a library to detect the media type from the image bytes (e.g., Apache Tika).
+            // For this example, IMAGE_JPEG is a common default.
+            headers.setContentType(MediaType.IMAGE_JPEG);
+
+            // Consider adding Cache-Control headers for better browser caching behavior, e.g.:
+            // headers.setCacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic().getHeaderValue());
+
+            return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
+        } else {
+            // This handles cases where the user exists but has no profile image,
+            // or if getProfileImage returns null for other reasons.
+            return ResponseEntity.notFound().build();
+        }
+        // Note: If userService.getProfileImage throws ResourceNotFoundException (user ID itself not found),
+        // it's expected to be handled by a global exception handler, returning 404.
+    }
+}

--- a/com/grv/grvapp/dtos/UserProfileUpdateRequestDto.java
+++ b/com/grv/grvapp/dtos/UserProfileUpdateRequestDto.java
@@ -1,0 +1,63 @@
+package com.grv.grvapp.dtos;
+
+/**
+ * Data Transfer Object for user profile update requests.
+ * Contains fields that can be updated for a user's profile.
+ */
+public class UserProfileUpdateRequestDto {
+
+    private String firstName;
+    private String lastName;
+
+    // Constructors
+
+    /**
+     * Default constructor.
+     */
+    public UserProfileUpdateRequestDto() {
+    }
+
+    /**
+     * Constructs a new DTO with specified first and last names.
+     * @param firstName The new first name.
+     * @param lastName The new last name.
+     */
+    public UserProfileUpdateRequestDto(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    // Getters and Setters
+
+    /**
+     * Gets the new first name for the user.
+     * @return The first name.
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Sets the new first name for the user.
+     * @param firstName The first name to set.
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * Gets the new last name for the user.
+     * @return The last name.
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Sets the new last name for the user.
+     * @param lastName The last name to set.
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/com/grv/grvapp/exceptions/ResourceNotFoundException.java
+++ b/com/grv/grvapp/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,22 @@
+package com.grv.grvapp.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Custom exception to indicate that a requested resource was not found.
+ * This exception, when thrown from a Spring MVC controller method or service layer
+ * and not caught elsewhere, will result in an HTTP 404 Not Found response.
+ * This is due to the {@link ResponseStatus} annotation.
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND) // Marks this exception to return HTTP 404
+public class ResourceNotFoundException extends RuntimeException {
+
+    /**
+     * Constructs a new ResourceNotFoundException with the specified detail message.
+     * @param message The detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     */
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/com/grv/grvapp/models/User.java
+++ b/com/grv/grvapp/models/User.java
@@ -1,0 +1,132 @@
+package com.grv.grvapp.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+/**
+ * Represents a user in the application.
+ * Contains basic profile information and a profile image.
+ */
+@Entity
+@Table(name = "users") // Specifies the database table name
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // Configures auto-increment for the ID
+    private Long id;
+
+    private String firstName;
+    private String lastName;
+
+    /**
+     * Stores the user's profile image as a byte array.
+     * Marked as {@code @Lob} to indicate that it can be a large object.
+     * The specific database column type (e.g., BLOB, BYTEA) will be determined by the JPA provider and database.
+     */
+    @Lob
+    private byte[] profileImage;
+
+    // Constructors
+
+    /**
+     * Default constructor for JPA.
+     */
+    public User() {
+    }
+
+    /**
+     * Constructs a new User with specified first and last names.
+     * @param firstName The user's first name.
+     * @param lastName The user's last name.
+     */
+    public User(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    // Getters and Setters
+
+    /**
+     * Gets the unique identifier of the user.
+     * @return The user's ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the unique identifier of the user.
+     * Typically managed by JPA and should not be set manually after creation.
+     * @param id The user's ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the user's first name.
+     * @return The first name.
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Sets the user's first name.
+     * @param firstName The new first name.
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * Gets the user's last name.
+     * @return The last name.
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Sets the user's last name.
+     * @param lastName The new last name.
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * Gets the user's profile image data.
+     * @return A byte array representing the profile image, or null if not set.
+     */
+    public byte[] getProfileImage() {
+        return profileImage;
+    }
+
+    /**
+     * Sets the user's profile image data.
+     * @param profileImage A byte array representing the profile image.
+     */
+    public void setProfileImage(byte[] profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    /**
+     * Returns a string representation of the User object.
+     * Excludes the {@code profileImage} field for brevity and to avoid large output.
+     * @return A string containing the user's ID, first name, and last name.
+     */
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                // Omitting profileImage from toString for brevity and security
+                '}';
+    }
+}

--- a/com/grv/grvapp/repositories/UserRepository.java
+++ b/com/grv/grvapp/repositories/UserRepository.java
@@ -1,0 +1,9 @@
+package com.grv.grvapp.repositories;
+
+import com.grv.grvapp.models.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/com/grv/grvapp/services/UserService.java
+++ b/com/grv/grvapp/services/UserService.java
@@ -1,0 +1,99 @@
+package com.grv.grvapp.services;
+
+import com.grv.grvapp.dtos.UserProfileUpdateRequestDto;
+import com.grv.grvapp.exceptions.ResourceNotFoundException;
+import com.grv.grvapp.models.User;
+import com.grv.grvapp.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * Service class for user-related operations.
+ * Handles business logic for managing user profiles and profile images.
+ */
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Constructs a new UserService with the given UserRepository.
+     * @param userRepository The repository for accessing user data.
+     */
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * Updates the profile information (e.g., first name, last name) for a given user.
+     * Fields in {@code requestDto} that are null will be ignored.
+     *
+     * @param userId The ID of the user to update.
+     * @param requestDto DTO containing the updated profile information.
+     * @return The updated User entity.
+     * @throws ResourceNotFoundException if no user is found with the given ID.
+     */
+    @Transactional
+    public User updateUserProfile(Long userId, UserProfileUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        // Update fields only if they are provided in the DTO
+        if (requestDto.getFirstName() != null) {
+            user.setFirstName(requestDto.getFirstName());
+        }
+        if (requestDto.getLastName() != null) {
+            user.setLastName(requestDto.getLastName());
+        }
+
+        return userRepository.save(user);
+    }
+
+    /**
+     * Uploads or updates the profile image for a given user.
+     * If {@code imageFile} is null or empty, the existing image is not changed by default.
+     *
+     * @param userId The ID of the user whose profile image is to be updated.
+     * @param imageFile The new profile image file.
+     * @return The updated User entity with the new profile image.
+     * @throws ResourceNotFoundException if no user is found with the given ID.
+     * @throws IOException if an error occurs during file processing.
+     */
+    @Transactional
+    public User uploadProfileImage(Long userId, MultipartFile imageFile) throws IOException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        if (imageFile != null && !imageFile.isEmpty()) {
+            user.setProfileImage(imageFile.getBytes());
+        } else {
+            // If imageFile is null or empty, current behavior is to not change the existing image.
+            // To clear the image, explicit logic would be needed here, e.g., user.setProfileImage(null);
+            // For now, we assume a valid, non-empty file is expected for an update action.
+        }
+
+        return userRepository.save(user);
+    }
+
+    /**
+     * Retrieves the profile image for a given user.
+     *
+     * @param userId The ID of the user whose profile image is to be retrieved.
+     * @return A byte array containing the image data, or null if the user has no profile image.
+     * @throws ResourceNotFoundException if no user is found with the given ID.
+     */
+    @Transactional(readOnly = true) // Good practice for read-only operations
+    public byte[] getProfileImage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        // Returns the byte array directly. Could be null if no image was ever set.
+        // Consider creating a specific ImageNotFoundException if a null/empty image needs distinct error handling upstream.
+        return user.getProfileImage();
+    }
+}

--- a/frontend/grvapp-frontend/src/pages/private/PrivateProfilePage.tsx
+++ b/frontend/grvapp-frontend/src/pages/private/PrivateProfilePage.tsx
@@ -1,35 +1,270 @@
+import React, { useState, useEffect, ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { FaEnvelope, FaUserCircle } from "react-icons/fa";
+import { FaEnvelope, FaUserCircle, FaCamera, FaSpinner } from "react-icons/fa";
 import ButtonHomeGrv from "../../components/buttons/ButtonHomeGrv";
 import SpinnerGrv from "../../components/feedback/SpinnerGrv";
 import { useUser } from "../../context/UserContext";
+import TextInputGrv from "../../components/forms/TextInputGrv";
+import { updateUserProfile, uploadProfileImage, getProfileImageUrl } from "../../services/api"; // Adjust path if needed
+import toast from 'react-hot-toast';
 
 const PrivateProfilePage = () => {
     const { t } = useTranslation();
-    const { user, loading } = useUser();
+    const { user, loading: userLoading, setUser } = useUser();
 
-    if (loading || !user) return <SpinnerGrv />;
+    // State for editable profile fields
+    const [firstName, setFirstName] = useState("");
+    const [lastName, setLastName] = useState("");
+
+    // State for image handling
+    const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null); // Currently selected file for upload
+    const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null); // Local blob URL for immediate preview
+    const [currentProfileImageUrl, setCurrentProfileImageUrl] = useState<string | null>(null); // URL of the currently saved profile image
+
+    // Loading states
+    const [isSaving, setIsSaving] = useState(false); // For text profile data
+    const [isUploadingImage, setIsUploadingImage] = useState(false); // For image upload
+
+    // State for cache-busting the profile image
+    // Both key and timestamp are used for robustness, though one might often suffice.
+    // Key forces React to re-create the img element, timestamp ensures URL is unique.
+    const [profileImageKey, setProfileImageKey] = useState<string>(Date.now().toString());
+
+    /**
+     * Populates form fields and fetches the current profile image URL
+     * when the user data is loaded or changed.
+     */
+    useEffect(() => {
+        if (user) {
+            setFirstName(user.firstName || "");
+            setLastName(user.lastName || "");
+            // Ensure user.id is available before attempting to generate the image URL.
+            // This is important as user data might be loaded asynchronously.
+            if (user.id) {
+                setCurrentProfileImageUrl(getProfileImageUrl(user.id));
+            }
+        }
+    }, [user]); // Dependency: re-run when user object changes.
+
+    /**
+     * Cleans up the local object URL (blob URL) created for image preview
+     * when the component unmounts or when the preview URL itself changes.
+     * This prevents memory leaks.
+     */
+    useEffect(() => {
+        return () => {
+            if (imagePreviewUrl && imagePreviewUrl.startsWith("blob:")) {
+                URL.revokeObjectURL(imagePreviewUrl);
+            }
+        };
+    }, [imagePreviewUrl]); // Dependency: re-run when imagePreviewUrl changes.
+
+    // Display spinner while user data is loading or if user/user.id is not yet available.
+    if (userLoading || !user) return <SpinnerGrv />;
+    if (!user.id) return <SpinnerGrv message={t('loadingUserSpecificData', 'Loading user data...')} />;
+
+    /**
+     * Handles the selection of a new profile image.
+     * Creates a local preview and then immediately attempts to upload the image.
+     * @param event The change event from the file input.
+     */
+    const handleImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
+        if (event.target.files && event.target.files[0]) {
+            const file = event.target.files[0];
+            setSelectedImageFile(file); // Store the selected file
+
+            // Create a local URL for immediate preview of the selected image.
+            // Revoke any existing blob URL to prevent memory leaks.
+            if (imagePreviewUrl && imagePreviewUrl.startsWith("blob:")) {
+                URL.revokeObjectURL(imagePreviewUrl);
+            }
+            const newPreviewUrl = URL.createObjectURL(file);
+            setImagePreviewUrl(newPreviewUrl);
+
+            // User ID is essential for the upload API endpoint.
+            if (!user.id) {
+                toast.error(t('errors.userIdMissing', "User ID is missing, cannot upload image."));
+                return;
+            }
+
+            setIsUploadingImage(true);
+            try {
+                // Call the API service to upload the image.
+                const updatedUser = await uploadProfileImage(user.id.toString(), file);
+                toast.success(t('profile.imageUploadSuccess', 'Image uploaded successfully!'));
+
+                // Update user context with the potentially updated user object from the backend.
+                if (setUser) setUser(updatedUser);
+
+                // Force refresh of the displayed profile image using cache-busting techniques.
+                setProfileImageKey(Date.now().toString()); // Changing the key forces React to re-render the <img> element.
+                setCurrentProfileImageUrl(`${getProfileImageUrl(user.id)}?t=${Date.now()}`); // Appending a timestamp makes the URL unique.
+
+                setImagePreviewUrl(null); // Clear the local preview, as the main image should now reflect the uploaded version.
+                setSelectedImageFile(null); // Clear the stored file.
+            } catch (error) {
+                console.error("Image upload failed:", error);
+                toast.error(t('profile.imageUploadFailed', 'Image upload failed. Please try again.'));
+                // Optionally, could clear imagePreviewUrl here to revert to the old image if upload fails.
+            } finally {
+                setIsUploadingImage(false);
+            }
+        }
+    };
+
+    /**
+     * Handles saving changes to the user's first and last names.
+     * Calls the API service to update the profile.
+     */
+    const handleSaveChanges = async () => {
+        if (!user.id) {
+            toast.error(t('errors.userIdMissing', "User ID is missing, cannot save changes."));
+            return;
+        }
+        setIsSaving(true);
+        try {
+            const updatedUserData = await updateUserProfile(user.id.toString(), { firstName, lastName });
+            toast.success(t('profile.profileUpdatedSuccess', 'Profile updated successfully!'));
+            if (setUser) setUser(updatedUserData); // Update user context.
+        } catch (error) {
+            console.error("Profile update failed:", error);
+            toast.error(t('profile.profileUpdateFailed', 'Profile update failed. Please try again.'));
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    // This variable was defined but not used. The JSX uses imagePreviewUrl and currentProfileImageUrl directly.
+    // const displayImageUrl = imagePreviewUrl || `${currentProfileImageUrl}?key=${profileImageKey}`;
 
     return (
-        <div className="max-w-xl mx-auto bg-surface dark:bg-dark-surface rounded-xl shadow-lg p-8 mt-8">
-            <div className="flex flex-col items-center gap-2">
-                <FaUserCircle className="text-6xl text-primary dark:text-dark-primary mb-2" />
-                <h2 className="text-2xl font-bold text-text dark:text-dark-text mb-1">
-                    {(user.firstName || "") + " " + (user.lastName || "")}
+        <div className="max-w-2xl mx-auto bg-surface dark:bg-dark-surface rounded-xl shadow-lg p-8 mt-8">
+            <div className="flex flex-col items-center gap-4">
+                {/* Profile Image Display and Upload Section */}
+                <div className="relative group w-32 h-32">
+                    {isUploadingImage ? (
+                        // Display a spinner while the image is uploading
+                        <div className="w-32 h-32 flex items-center justify-center bg-gray-200 dark:bg-gray-700 rounded-full">
+                            <FaSpinner className="animate-spin text-4xl text-primary dark:text-dark-primary" />
+                        </div>
+                    ) : (
+                        // Display image preview or current profile image
+                        <>
+                            {imagePreviewUrl ? (
+                                // Show local preview if a new image has been selected
+                                <img src={imagePreviewUrl} alt={t('profile.previewAlt', "Profile Preview")} className="w-32 h-32 rounded-full object-cover shadow-md" />
+                            ) : currentProfileImageUrl ? (
+                                // Show current profile image fetched from backend
+                                <img
+                                    key={profileImageKey} // React key: forces re-render if key changes (used for cache busting)
+                                    src={currentProfileImageUrl} // Source URL, potentially with cache-busting timestamp
+                                    alt={t('profile.alt', "Profile")}
+                                    className="w-32 h-32 rounded-full object-cover shadow-md bg-gray-300 dark:bg-gray-600"
+                                    onError={(e) => {
+                                        // Image error handling:
+                                        // 1. If the initial load fails, try once more with a cache-busting timestamp.
+                                        // This can help if a CDN or browser cache serves a stale image after an update.
+                                        const target = e.currentTarget;
+                                        if (!target.src.includes('?t=')) {
+                                            target.src = `${getProfileImageUrl(user.id)}?t=${Date.now()}`; // Use getProfileImageUrl to ensure base is correct
+                                        } else {
+                                           // 2. If the cache-busted version also fails, hide the <img> tag.
+                                           // The fallback FaUserCircle icon will then be displayed.
+                                           target.style.display = 'none';
+                                        }
+                                    }}
+                                    onLoad={(e) => {
+                                        // Ensure image is visible if it loads successfully (e.g., after an error and successful retry)
+                                        e.currentTarget.style.display = 'block';
+                                    }}
+                                />
+                            ) : null}
+
+                            {/* Fallback Icon Logic:
+                                Displayed if:
+                                - No local image preview is active, AND
+                                - EITHER no currentProfileImageUrl is set (user has no image)
+                                - OR the <img> tag for currentProfileImageUrl is hidden due to loading error.
+                                  (The DOM query here is a bit of a workaround for not having a dedicated 'imageLoadFailed' state,
+                                   but often works for this kind of fallback).
+                            */}
+                            { !imagePreviewUrl && (!currentProfileImageUrl || (document.querySelector(`img[key="${profileImageKey}"]`) as HTMLImageElement)?.style.display === 'none' ) && (
+                                 <FaUserCircle className="w-32 h-32 text-primary dark:text-dark-primary" />
+                            )}
+                        </>
+                    )}
+                    {/* Image upload button (camera icon), hidden during upload */}
+                    {!isUploadingImage && (
+                        <label htmlFor="profileImageInput" title={t('profile.changeImageTitle', "Change profile image")} className="absolute bottom-0 right-0 bg-secondary dark:bg-dark-secondary text-white p-2 rounded-full cursor-pointer hover:bg-secondary-dark dark:hover:bg-dark-secondary-dark transition-colors group-hover:opacity-100 opacity-0">
+                            <FaCamera />
+                        </label>
+                    )}
+                    <input
+                        type="file"
+                        id="profileImageInput"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={handleImageChange}
+                        disabled={isUploadingImage}
+                    />
+                </div>
+
+                <h2 className="text-2xl font-bold text-text dark:text-dark-text">
+                    {firstName} {lastName}
                 </h2>
-                <span className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                <span className="text-sm text-gray-500 dark:text-gray-400">
                     @{user.username || ""}
                 </span>
             </div>
-            <div className="flex flex-col gap-4 mt-4">
-                <div className="flex items-center gap-3">
+
+            <div className="mt-8 space-y-6">
+                <div>
+                    <label htmlFor="firstName" className="block text-sm font-medium text-text dark:text-dark-text mb-1">
+                        {t('profile.firstNameLabel', 'First Name')}
+                    </label>
+                    <TextInputGrv
+                        id="firstName"
+                        name="firstName"
+                        value={firstName}
+                        onChange={(e) => setFirstName(e.target.value)}
+                        placeholder={t('profile.firstNamePlaceholder', 'Enter your first name')}
+                        disabled={isSaving}
+                    />
+                </div>
+
+                <div>
+                    <label htmlFor="lastName" className="block text-sm font-medium text-text dark:text-dark-text mb-1">
+                        {t('profile.lastNameLabel', 'Last Name')}
+                    </label>
+                    <TextInputGrv
+                        id="lastName"
+                        name="lastName"
+                        value={lastName}
+                        onChange={(e) => setLastName(e.target.value)}
+                        placeholder={t('profile.lastNamePlaceholder', 'Enter your last name')}
+                        disabled={isSaving}
+                    />
+                </div>
+
+                <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
                     <FaEnvelope className="text-lg text-secondary dark:text-dark-secondary" />
                     <span className="text-text dark:text-dark-text">{user.email || ""}</span>
                 </div>
-                <ButtonHomeGrv />
+
+                <button
+                    type="button"
+                    onClick={handleSaveChanges}
+                    disabled={isSaving || isUploadingImage}
+                    className="w-full bg-primary hover:bg-primary-dark dark:bg-dark-primary dark:hover:bg-dark-primary-dark text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary dark:focus:ring-offset-dark-surface dark:focus:ring-dark-primary disabled:opacity-50 flex items-center justify-center"
+                >
+                    {isSaving ? <FaSpinner className="animate-spin mr-2" /> : null}
+                    {t('profile.saveChangesButton', 'Save Changes')}
+                </button>
+
+                <div className="mt-6 text-center">
+                    <ButtonHomeGrv />
+                </div>
             </div>
-
-
         </div>
     );
 };

--- a/frontend/grvapp-frontend/src/services/api.tsx
+++ b/frontend/grvapp-frontend/src/services/api.tsx
@@ -1,18 +1,94 @@
 import axios from "axios";
+import { User } from "../context/UserContext"; // Assuming User type is available here
 
-// Puedes ajustar la URL base según tu entorno
-const API_URL = "http://localhost:8080/api";
+// Base URL is already defined
+const API_URL = "http://localhost:8080/api"; // Keep existing or use environment variable
 
-export const getUserProfile = async (username: string) => {
-
+// Helper to get token, to keep it DRY
+/**
+ * Retrieves authentication headers.
+ * Reads the JWT token from localStorage.
+ * @returns An object containing the Authorization header if token is found, otherwise an empty object.
+ * @remarks In a production app, missing token might trigger a redirect to login or throw an error.
+ */
+const getAuthHeaders = () => {
     const token = localStorage.getItem("token");
+    if (!token) {
+        console.warn("Authentication token not found. API calls may fail.");
+        // Depending on app strategy, could throw an error here or return a more specific signal.
+        return {};
+    }
+    return { Authorization: `Bearer ${token}` };
+};
 
-    console.log("Token:", token);
-    console.log("URL:", `${API_URL}/users/${username}`);
-    const response = await axios.get(`${API_URL}/users/${username}`, {
+/**
+ * Fetches a user's profile by their username.
+ * @param username The username of the user to fetch.
+ * @returns A Promise resolving to the User object.
+ * @throws Will throw an error if the request fails (e.g., network error, user not found).
+ */
+export const getUserProfile = async (username: string): Promise<User> => {
+    const response = await axios.get(`${API_URL}/users/username/${username}`, {
+        headers: getAuthHeaders(),
+    });
+    return response.data; // Axios automatically throws for non-2xx responses
+};
+
+/**
+ * Updates a user's profile information.
+ * @param userId The ID of the user to update.
+ * @param data An object containing the fields to update (e.g., firstName, lastName).
+ * @returns A Promise resolving to the updated User object.
+ * @throws Will throw an error if the request fails.
+ */
+export const updateUserProfile = async (userId: string, data: { firstName?: string, lastName?: string }): Promise<User> => {
+    const response = await axios.put(`${API_URL}/users/${userId}/profile`, data, {
         headers: {
-            Authorization: `Bearer ${token}`,
+            ...getAuthHeaders(),
+            'Content-Type': 'application/json',
         },
     });
+    // Axios throws an error for non-2xx status codes by default.
+    // The explicit check below is redundant if this default behavior is relied upon.
+    // However, if specific handling for statuses like 201, 204 were needed without error,
+    // then more detailed checks or axios's `validateStatus` option would be used.
+    if (response.status !== 200) {
+        throw new Error(response.data?.message || 'Failed to update profile');
+    }
     return response.data;
+};
+
+/**
+ * Uploads a profile image for the specified user.
+ * @param userId The ID of the user for whom the image is being uploaded.
+ * @param imageFile The image file to upload.
+ * @returns A Promise resolving to the updated User object (assuming the backend returns this).
+ * @throws Will throw an error if the request fails.
+ */
+export const uploadProfileImage = async (userId: string, imageFile: File): Promise<User> => {
+    const formData = new FormData();
+    formData.append('image', imageFile); // "image" must match @RequestParam name in backend
+
+    const response = await axios.post(`${API_URL}/users/${userId}/image`, formData, {
+        headers: {
+            ...getAuthHeaders(),
+            // 'Content-Type': 'multipart/form-data' is automatically set by the browser
+            // when using FormData with axios/fetch, including the boundary.
+            // Manually setting it can lead to errors.
+        },
+    });
+    // Similar to updateUserProfile, axios handles non-2xx errors by default.
+    if (response.status !== 200) {
+        throw new Error(response.data?.message || 'Failed to upload image');
+    }
+    return response.data;
+};
+
+/**
+ * Constructs the URL for a user's profile image.
+ * @param userId The ID of the user.
+ * @returns The full URL string to the user's profile image.
+ */
+export const getProfileImageUrl = (userId: string | number): string => {
+    return `${API_URL}/users/${userId}/image`;
 };


### PR DESCRIPTION
This feature enables users to edit their profile information (first name, last name) and upload a profile image. The changes are persisted in the database, and the updated information is reflected in the user's profile page.

Backend changes:
- Added PUT endpoint `/api/users/{userId}/profile` to update user details.
- Added POST endpoint `/api/users/{userId}/image` to upload profile images (stored as byte arrays in the DB).
- Added GET endpoint `/api/users/{userId}/image` to retrieve profile images.
- Updated `User` entity with `profileImage` field (@Lob).
- Enhanced `UserService` with methods for profile updates and image handling.
- Added `UserProfileUpdateRequestDto` for profile data.
- Implemented `ResourceNotFoundException` for error handling.
- Added Javadoc comments and logging.

Frontend changes:
- Enhanced `PrivateProfilePage.tsx` with input fields for first/last name and an image upload interface.
- Implemented client-side image preview.
- Added API service functions in `api.tsx` to interact with backend endpoints for profile updates and image operations.
- Connected UI elements to service functions, including loading states and toast notifications for user feedback.
- Updated `UserContext` with new data upon successful updates.
- Implemented image cache-busting for reliable display of new images.
- Added TSDoc comments and inline explanations.